### PR TITLE
Use `static` instead of `self` to allow extension in tests

### DIFF
--- a/src/ComposerLocator.tpl.php
+++ b/src/ComposerLocator.tpl.php
@@ -22,11 +22,11 @@ abstract class ComposerLocator
     {
         $name = strtolower($name);
 
-        if (! isset(self::$paths[$name])) {
+        if (! isset(static::$paths[$name])) {
             throw new RuntimeException("Composer package not found: {$name}");
         }
 
-        return self::getRootPath() . self::$paths[$name];
+        return static::getRootPath() . static::$paths[$name];
     }
 
     /**
@@ -44,7 +44,7 @@ abstract class ComposerLocator
      */
     public static function isInstalled($name)
     {
-        return isset(self::$paths[$name]);
+        return isset(static::$paths[$name]);
     }
 
     /**
@@ -52,7 +52,7 @@ abstract class ComposerLocator
      */
     public static function getPackages()
     {
-        return array_keys(self::$paths);
+        return array_keys(static::$paths);
     }
 
     /**
@@ -62,8 +62,8 @@ abstract class ComposerLocator
     {
         $paths = [];
         
-        foreach (self::$paths as $name => $path) {
-            $paths[$name] = self::getRootPath() . $path;
+        foreach (static::$paths as $name => $path) {
+            $paths[$name] = static::getRootPath() . $path;
         }
         
         return $paths;


### PR DESCRIPTION
I'm trying to use this package in another package but the static class/methods make it difficult to test it (i.e. simulate a package being installed in Composer to test what happens then).

A workaround I see is using `static` instead of `self`, that would allow to extend the class like this:

```php
class FakeComposerLocator extends ComposerLocator
{
    public static $paths = [];
}
```

Then in my tests I can make my system use `FakeComposerLocator` instead of `ComposerLocator` and I can register fake packages like this:

```php
FakeComposerLocator::$paths = ['foo/bar'];
```

Not the cleanest solution, but better than nothing?