### PR TITLE
Remove exception on uninstall

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -5,7 +5,6 @@ namespace mindplay\composer_locator;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
-use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem;
 
 class Plugin implements PluginInterface
@@ -55,8 +54,6 @@ class Plugin implements PluginInterface
                 $fs->dumpFile($output_path, $content);
 
                 $io->write("<info>" . count($packages) . " package paths dumped</info>");
-            } else {
-                throw new RuntimeException("internal error - failed to enumerate packages");
             }
         };
 


### PR DESCRIPTION
Uninstalling the plugin causes the exception to be thrown. Not sure if there's a way to tell if the plugin is being uninstalled, and so only skip in that case.